### PR TITLE
Add firewalld options

### DIFF
--- a/ActiveTmp.sh
+++ b/ActiveTmp.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC2181
 #
 # Script to ensure that host has /tmp as tmpfs
 #

--- a/ChrootBuild.sh
+++ b/ChrootBuild.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck disable=SC2005,SC2001
+# shellcheck disable=SC2005,SC2001,SC2181
 #
 # Install minimal RPM-set into chroot
 #

--- a/DiskSetup.sh
+++ b/DiskSetup.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC2181
 #
 # Script to automate basic setup of CHROOT device
 #

--- a/GrubSetup.sh
+++ b/GrubSetup.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# shellcheck disable=
+# shellcheck disable=SC2181
 #
 # Script to set up the chroot'ed /etc/fstab
 # - Pass in the name of the EBS device the chroot was built on

--- a/MkTabs.sh
+++ b/MkTabs.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC2181
 #
 # Script to set up the chroot'ed /etc/fstab
 #


### PR DESCRIPTION
* Add some "safety" rules via INPUT_direct chain. These rules will help prevent unanticipated sadness if someone changes an instance's default firewalld zone from 'public' to something more-restrictive (like 'drop')