### PR TITLE
Spiffs

### DIFF
--- a/Docs/README_BootstrapAMIselection.md
+++ b/Docs/README_BootstrapAMIselection.md
@@ -1,17 +1,24 @@
 In order to produce AMIs that support desired features, it is important that the AMI used to bootstrap from supports those same features:
 
 * For candidate RHEL 7 bootstrap AMIs: ensure that the AMI has a valid `billingProducts` value set (typically `bp-6fa54006`). This gives resultant AMIs access to the Red Hat RPM repositories. At this point in time,  a way to use the AWS APIs/utilities to pull attribute information directly from an unlaunched AMI has yet to be identified. The only currently-known way is per the notes in this [BlogSpot post](https://thjones2.blogspot.com/2015/03/so-you-dont-want-to-byol.html).
-* For all EL 7 bootstrap AMIs: ensure that the AMI has SriovNetSupport support enabled. This gives resultant AMIs the ability to produce instances that support 10Gbps networking mode.
-
-    ~~~
-$ aws --profile <PROFILE_NAME> ec2 --region <REGION> describe-image-attribute --image-id <AMI_ID> \
-  --attribute sriovNetSupport
-{
-    "SriovNetSupport": {
-        "Value": "simple"
-    },
-    "ImageId": "<AMI_ID>"
-}
-    ~~~
-
+* For all EL 7 bootstrap AMIs:
+    * Ensure that the AMI has SriovNetSupport support enabled. This gives resultant AMIs the ability to produce instances that support 10Gbps networking mode.
+        ~~~
+        $ aws --profile <PROFILE_NAME> --region <REGION> ec2 describe-image-attribute --image-id <AMI_ID> \
+          --attribute sriovNetSupport
+        {
+            "SriovNetSupport": {
+                "Value": "simple"
+            },
+            "ImageId": "<AMI_ID>"
+        }
+        ~~~
+    * Ensure that the AMI has Elastic Network Adapter (ENA) support enabled. This allows the resultant AMIs (EL 7.4.1708 or newer) to take advantage of instance-types with 20Gbps+ networking mode.
+        ~~~
+        $ aws --profile <PROFILE_NAME>  --region <REGION> ec2 describe-images --image-id <AMI_ID> \
+          --query 'Images[].EnaSupport'
+        [
+            true
+        ]
+        ~~~
 **Note:** for AMIs not owned by your account, you likely will not have sufficient permissions to read the AMI's attribute values.

--- a/Docs/README_PrivateRun.md
+++ b/Docs/README_PrivateRun.md
@@ -37,7 +37,10 @@ Once the above sequence exits successfully, an AMI may be created from the targe
 1. Detach boot EBS
 1. Detach build-EBS
 1. Re-attach build-EBS to boot EBS's original location
-1. Register an AMI from the stopped instance
+1. Create or register an AMI:
+    * If you wish to inherit an attribute like a [`billingProducts` tag](https://thjones2.blogspot.com/2015/03/so-you-dont-want-to-byol.html), use the `register-image` AMI-creation method to create an AMI from the stopped image.
+    * If you wish to ensure that the AMI does not inherit an attribute like a `billingProducts`, create a snapshot of the boot EBS and use the `create-image` AMI-creation method to create an AMI from the snapshot.
+
 1. Launch a test-instance from the newly-created AMI and verify that it functions as expected.
 
 The OS-specific components can be further automated by using frameworks like [Packer](https://www.packer.io/). One such project that does this is Plus3 IT's [spel](https://github.com/plus3it/spel) project.

--- a/Docs/README_PublicRun.md
+++ b/Docs/README_PublicRun.md
@@ -29,7 +29,9 @@ Once the above sequence exits successfully, an AMI may be created from the targe
 1. Detach boot EBS
 1. Detach build-EBS
 1. Re-attach build-EBS to boot EBS's original location
-1. Register an AMI from the stopped instance
+1. Create or register an AMI:
+    * If you wish to inherit an attribute like a [`billingProducts` tag](https://thjones2.blogspot.com/2015/03/so-you-dont-want-to-byol.html), use the `register-image` AMI-creation method to create an AMI from the stopped image.
+    * If you wish to ensure that the AMI does not inherit an attribute like a `billingProducts`, create a snapshot of the boot EBS and use the `create-image` AMI-creation method to create an AMI from the snapshot.
 1. Launch a test-instance from the newly-created AMI and verify that it functions as expected.
 
 The OS-specific components can be further automated by using frameworks like [Packer](https://www.packer.io/). One such project that does this is Plus3 IT's [spel](https://github.com/plus3it/spel) project.

--- a/GrubSetup.sh
+++ b/GrubSetup.sh
@@ -42,7 +42,10 @@ then
     printf "GRUB_DISABLE_LINUX_UUID=true\n"
     printf "GRUB_DISABLE_RECOVERY=\"true\"\n"
     printf "GRUB_TERMINAL_OUTPUT=\"console\"\n"
-    printf "GRUB_CMDLINE_LINUX=\"console=tty0 crashkernel=auto console=ttyS0,115200n8 "
+    # Set GRUB2 vconsole output behavior
+    printf "GRUB_CMDLINE_LINUX=\"crashkernel=auto vconsole.keymap=us "
+    printf "vconsole.font=latarcyrheb-sun16 console=tty0 "
+    printf "console=ttyS0,115200n8 "
     # Disable systemd's predictable network interface naming behavior
     printf "net.ifnames=0 "
     # Enable FIPS mode ...and make it accept the /boot partition

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # Introduction
 The scripts in this project are designed to ease the creation of LVM-enabled Enterprise Linux AMIs for use in AWS envrionments. It has been successfully tested with CentOS 7.x, Scientific Linux 7.x and Red Hat Enterprise Linux 7.x. It should work with other EL7-derived operating systems.
 
+Note: The scripts _can_ also be used to generate bootstrap and/or recovery AMIs: non-LVMed AMIs intended to help generate the LVM-enabled AMIs or recover LVM-enabled instances. However, this functionality is only lightly tested. It is known to produce CentOS 7.x AMIs suitable for bootstrapping. It is also known to _not_ produce RHEL 7.x AMIs suitable for bootstrapping. As this is not the scripts' primary use-case, documentation for such is not included (though it should be easy enough for an experienced EL7 adminstrator to figure out from reading the scripts' contents).
+
 
 ## Table of Contents
 
 * [Required RPMs](Docs/README_dependencies.md)
 * [Scripts](Docs/README_scripts.md)
 * How to run:
-  * Select a suitable, generic AMI (e.g. one published by Red Hat, Inc. or CentOS.Org) to use to bootstrap the the new AMI from (see the [AMI selection](Docs/README_BootstrapAMIselection.md) README)
+  * Select a suitable, generic AMI (e.g. one published by Red Hat, Inc. or CentOS.Org) to use to bootstrap the new AMI from (see the [AMI selection](Docs/README_BootstrapAMIselection.md) README)
   * Via build-instance hosted on a [Public Network](Docs/README_PublicRun.md)
   * Via build-instance hosted on a [Private Network](Docs/README_PrivateRun.md)
 * Verify that the resultant AMI supports the expected features (see the [Instance Verification](Docs/README_InstanceVerification.md) README)


### PR DESCRIPTION
Misc. updates and fixups to documentation:
- Nuke a duplicate "the" from main README
- Update bootstrap AMI-selection README to reflect EL 7.4.1708's native ability to support ENA
- Update public- and private-run READMEs to reflect different AMI registration methods (and associated rationales)