### PR TITLE
Enables dns resolution in the chroot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,6 @@ env:
     - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
     - SEGFAULT_SIGNALS=all
 
-addons:
-  apt:
-    sources:
-      - debian-sid    # Grab ShellCheck from the Debian repo
-    packages:
-      - shellcheck
-
 matrix:
   include:
     - env:

--- a/ChrootBuild.sh
+++ b/ChrootBuild.sh
@@ -37,6 +37,12 @@ function PrepChroot() {
                      echo yum-utils
                    ))
 
+   # Enable DNS resolution in the chroot
+   if [[ ! -e ${CHROOT}/etc/resolv.conf ]]
+   then
+      install -m 0644 /etc/resolv.conf "${CHROOT}/etc"
+   fi
+
    # Do this so that install of chkconfig RPM succeeds
    if [[ ! -e ${CHROOT}/etc/init.d ]]
    then


### PR DESCRIPTION
#### Description:

- Enables DNS resolution from the chroot jail

#### Rationale:

- Package installs (`awscli-bundle.zip` in particular) sometimes require resolution to install successfully
