### PR TITLE
Makes scripts compatibile with unofficial bash strict mode (-eu -o pipefail)

### DIFF
--- a/AWScliSetup.sh
+++ b/AWScliSetup.sh
@@ -33,10 +33,10 @@ then
 fi
 
 # Enable the RHEL "optional" repo where appropriate
-OPTIONREPO=$(yum repolist all | grep rhel-server-optional | sed 's/\/.*$//')
+OPTIONREPO=$(yum repolist all | grep rhel-server-optional || true)
 if [[ ${OPTIONREPO} != "" ]]
 then
-   chroot "${CHROOT}" yum-config-manager --enable "${OPTIONREPO}"
+   chroot "${CHROOT}" yum-config-manager --enable "${OPTIONREPO/\/*/}"
 fi
 
 # Enabled requested repos in chroot() environment

--- a/AWScliSetup.sh
+++ b/AWScliSetup.sh
@@ -80,7 +80,7 @@ rm -rf "${CHROOT}/root/awscli-bundle"
 # Depending on RPMs dependencies, this may fail if a repo is
 # missing (e.g. EPEL). Will also fail if no RPMs are present
 # in the search directory.
-yum install -y "${EPELRELEASE}"
-yum --installroot="${CHROOT}" install -y "${EPELRELEASE}"
+{ STDERR=$(yum install -y "${EPELRELEASE}" 2>&1 1>&$out); } {out}>&1 || echo "$STDERR" | grep "Error: Nothing to do"
+{ STDERR=$(yum --installroot="${CHROOT}" install -y "${EPELRELEASE}" 2>&1 1>&$out); } {out}>&1 || echo "$STDERR" | grep "Error: Nothing to do"
 yum --installroot="${CHROOT}" install -y "${SCRIPTROOT}"/AWSpkgs/*.noarch.rpm \
    || exit $?

--- a/ChrootBuild.sh
+++ b/ChrootBuild.sh
@@ -73,7 +73,8 @@ function PrepChroot() {
    then
       for RPM in "${REPORPMS[@]}"
       do
-         rpm --root "${CHROOT}" -ivh --nodeps "${RPM}"
+         rpm --root "${CHROOT}" -ivh --nodeps "${RPM}" || \
+            rpm --root "${CHROOT}" -ivh --nodeps "${RPM}" 2>&1 | grep "is already installed"
       done
    fi
 }

--- a/ChrootBuild.sh
+++ b/ChrootBuild.sh
@@ -73,8 +73,7 @@ function PrepChroot() {
    then
       for RPM in "${REPORPMS[@]}"
       do
-         rpm --root "${CHROOT}" -ivh --nodeps "${RPM}" || \
-            rpm --root "${CHROOT}" -ivh --nodeps "${RPM}" 2>&1 | grep "is already installed"
+         { STDERR=$(rpm --root "${CHROOT}" -ivh --nodeps "${RPM}" 2>&1 1>&$out); } {out}>&1 || echo "$STDERR" | grep "is already installed"
       done
    fi
 }

--- a/DiskSetup.sh
+++ b/DiskSetup.sh
@@ -53,6 +53,7 @@ function CarveLVM() {
   systemctl stop boot.mount
 
    # Create LVM objects
+   LVCSTAT=0
    vgcreate -y "${VGNAME}" "${CHROOTDEV}${PARTPRE}2" || LogBrk 5 "VG creation failed. Aborting!"
    lvcreate --yes -W y -L "${ROOTVOL[1]}" -n "${ROOTVOL[0]}" "${VGNAME}" || LVCSTAT=1
    lvcreate --yes -W y -L "${SWAPVOL[1]}" -n "${SWAPVOL[0]}" "${VGNAME}" || LVCSTAT=1

--- a/DiskSetup.sh
+++ b/DiskSetup.sh
@@ -68,9 +68,7 @@ function CarveLVM() {
    fi
 
    # Gather info to diagnose seeming /boot race condition
-   grep "${BOOTLABEL}" /proc/mounts
-   # shellcheck disable=SC2181
-   if [[ $? -eq 0 ]]
+   if [[ $(grep -q "${BOOTLABEL}" /proc/mounts)$? -eq 0 ]]
    then
      tail -n 100 /var/log/messages
      sleep 3

--- a/DiskSetup.sh
+++ b/DiskSetup.sh
@@ -50,7 +50,7 @@ function CarveLVM() {
       mkpart primary ext4 ${BOOTDEVSZ} 100% set 2 lvm
 
    # Stop/umount boot device, in case parted/udev/systemd managed to remount it
-  systemctl stop boot.mount
+  systemctl stop boot.mount || true
 
    # Create LVM objects
    LVCSTAT=0
@@ -77,7 +77,7 @@ function CarveLVM() {
 
    # Stop/umount boot device, in case parted/udev/systemd managed to remount it
    # again.
-  systemctl stop boot.mount
+  systemctl stop boot.mount || true
 
    # Create filesystems
    mkfs -t ext4 -L "${BOOTLABEL}" "${CHROOTDEV}${PARTPRE}1" || err_exit "Failure creating filesystem - /boot"


### PR DESCRIPTION
#### Description:

- Makes scripts compatibile with unofficial bash strict mode (`-eu -o pipefail`)

#### Rationale:

- Unhandled errors were making it difficult to troubleshoot _where_ failures were occurring. Scripts would only exit non-zero if the _last_ command failed. Failures elsewhere would not exit, causing problems later in the build and making it hard to figure out the root cause.
