### PR TITLE
Avoids failure caused by misquoted package list

### DIFF
--- a/ChrootBuild.sh
+++ b/ChrootBuild.sh
@@ -167,8 +167,9 @@ case "${FIPSDISABLE}" in
 esac
 
 # Install main RPM-groups
+# shellcheck disable=SC2046
 ${YUMDO} @core -- \
-"$(rpm --qf '%{name}\n' -qf /etc/yum.repos.d/* 2>&1 | grep -v "not owned" | sort -u)" \
+    $(rpm --qf '%{name}\n' -qf /etc/yum.repos.d/* 2>&1 | grep -v "not owned" | sort -u) \
     authconfig \
     chrony \
     cloud-init \


### PR DESCRIPTION
#### Description:

- Removes quotes around command substitution so newlines are returned as spaces

#### Rationale:

- Builds using the RHEL7 recovery AMI were failing because of bad syntax in the command `'epel-release` instead of just `epel-release`:

```bash
+ yum --nogpgcheck --installroot=/mnt/ec2-root '--disablerepo=*' --enablerepo=rhui-REGION-client-config-server-7,rhui-REGION-rhel-server-releases,rhui-REGION-rhel-server-rh-common,rhui-REGION-rhel-server-optional,rhui-REGION-rhel-server-extras,epel install -y @core -- 'epel-release
rh-amazon-rhui-client
subscription-manager' authconfig chrony cloud-init cloud-utils-growpart dracut-config-generic dracut-fips dracut-norescue gdisk grub2 grub2-tools iptables-services iptables-utils kernel kexec-tools lvm2 ntp ntpdate openssh-clients openssh-server rootfiles rsync selinux-policy-targeted sudo tar vim-common wget yum-utils -abrt -abrt-addon-ccpp -abrt-addon-kerneloops -abrt-addon-python -abrt-cli -abrt-libs -aic94xx-firmware -alsa-firmware -alsa-lib -alsa-tools-firmware -biosdevname -gcc-gfortran -iprutils -ivtv-firmware -iwl1000-firmware -iwl100-firmware -iwl105-firmware -iwl135-firmware -iwl2000-firmware -iwl2030-firmware -iwl3160-firmware -iwl3945-firmware -iwl4965-firmware -iwl5000-firmware -iwl5150-firmware -iwl6000-firmware -iwl6000g2a-firmware -iwl6000g2b-firmware -iwl6050-firmware -iwl7260-firmware -libertas-sd8686-firmware -libertas-sd8787-firmware -libertas-usb8388-firmware -libvirt-client -libvirt-devel -libvirt-java -libvirt-java-devel -nc -NetworkManager -plymouth -sendmail
Loaded plugins: amazon-id, product-id, rhui-lb, search-disabled-repos, subscription-manager
This system is not registered with an entitlement server. You can use subscription-manager to register.
epel/x86_64/metalink                                                                                                                                                                           |  14 kB  00:00:00
epel                                                                                                                                                                                           | 3.2 kB  00:00:00
rhui-REGION-client-config-server-7                                                                                                                                                             | 2.9 kB  00:00:00
rhui-REGION-rhel-server-extras                                                                                                                                                                 | 3.4 kB  00:00:00
rhui-REGION-rhel-server-optional                                                                                                                                                               | 3.3 kB  00:00:00
rhui-REGION-rhel-server-releases                                                                                                                                                               | 3.5 kB  00:00:00
rhui-REGION-rhel-server-rh-common                                                                                                                                                              | 3.8 kB  00:00:00
(1/3): epel/x86_64/group_gz                                                                                                                                                                    |  88 kB  00:00:00
(2/3): epel/x86_64/primary                                                                                                                                                                     | 3.6 MB  00:00:01
(3/3): epel/x86_64/updateinfo                                                                                                                                                                  | 933 kB  00:00:02
epel                                                                                                                                                                                                      12746/12746
Error: Invalid version flag from: epel-release
rh-amazon-rhui-client
subscription-manager
```
