### PR TITLE
Validates all included/requested pkgs are installed

### DIFF
--- a/ChrootBuild.sh
+++ b/ChrootBuild.sh
@@ -247,11 +247,17 @@ EXCLUDE_PKGS=(
     -sendmail
 )
 
+# Strip excluded pkgs from the include list
+for PKG in "${EXCLUDE_PKGS[@]}"
+do
+    mapfile -t INCLUDE_PKGS < <(printf '%s\n' "${INCLUDE_PKGS[@]}" | grep -xv "^${PKG/-/}$")
+done
+
 # Install main RPM-groups
 $YUMDO -- "${INCLUDE_PKGS[@]}" "${EXCLUDE_PKGS[@]}"
 
 # Validate all included packages were installed
-rpm -q "${INCLUDE_PKGS[@]}"
+rpm --root "${CHROOT}" -q "${INCLUDE_PKGS[@]}"
 
 # Install additionally-requested RPMs
 if [[ ! -z ${EXTRARPMS+xxx} ]]

--- a/ChrootBuild.sh
+++ b/ChrootBuild.sh
@@ -175,7 +175,6 @@ INCLUDE_PKGS+=(
     cloud-init
     cloud-utils-growpart
     dracut-config-generic
-    dracut-norescue
     gdisk
     grub2
     grub2-tools


### PR DESCRIPTION
#### Description:

- Constructs arrays of "included" and "excluded" packages, with the package list passed to yum as before. The difference now is that the "include" package list is verified using `rpm -q` to ensure that all requested packages are truly installed.

#### Rationale:

- Yum will exit with a success if multiple packages are specified and if _any_ of them install. If one of them does not install, it still exits zero. We want to ensure that any specified package truly is installed, and is not skipped due to a misspelling or some other error. Such errors should cause a non-zero exit, so that they can be fixed.
