### PR TITLE
ELVERSION variable returns el7.6 which fails case

### DIFF
--- a/GetAmznLx.sh
+++ b/GetAmznLx.sh
@@ -8,7 +8,7 @@ SCRIPTROOT="$(dirname ${0})"
 CHROOT="${CHROOT:-/mnt/ec2-root}"
 PROJECT="Lx-GetAMI-Utils"
 AMZNLXGIT="${1:-https://github.com/ferricoxide/${PROJECT}.git}"
-ELVERSION="el$(rpm --qf '%{version}' -q $(rpm -qf /etc/redhat-release))"
+ELVERSION="el$(rpm --qf '%{version}' -q $(rpm -qf /etc/redhat-release)| cut -d . -f 1)"
 
 # Fetch Amzn.Linux RPMs if necessary
 if [[ -d ${SCRIPTROOT}/../${PROJECT} ]]


### PR DESCRIPTION
ELVERSION variable declaration on line 11 returns "el7.6" which causes case evaluation on line 29 to fail and exit with "Platform not supported. Aborting...".

On line 11, added cut to end of command in parentheses to remove .6 from results.

- Fixes #61
