### PR TITLE
Assigns default value properly to DEVFSTYP

### DIFF
--- a/MkChrootTree.sh
+++ b/MkChrootTree.sh
@@ -7,7 +7,7 @@
 #######################################################################
 CHROOTDEV=${1:-UNDEF}
 ALTROOT="${CHROOT:-/mnt/ec2-root}"
-DEVFSTYP="${2:ext4}"
+DEVFSTYP="${2:-ext4}"
 
 if [[ ${CHROOTDEV} =~ /dev/nvme ]]
 then


### PR DESCRIPTION
#### Description:

Assigns default value properly for the DEVFSTYP variable

#### Rationale:

Default value was not actually being assigned, causing failures when executed with `set -u` enabled.

