### PR TITLE
Don't force pvcreate if re-using boot EBS

### DIFF
--- a/DiskSetup.sh
+++ b/DiskSetup.sh
@@ -55,7 +55,13 @@ function CarveLVM() {
 
    # Create LVM objects
    LVCSTAT=0
-   pvcreate "${CHROOTDEV}${PARTPRE}2" || LogBrk 5 "PV creation failed. Aborting!"
+   # Let's only attempt this if we're a secondary EBS
+   if [[ ${CHROOTDEV} == /dev/xvda ]] || [[ ${CHROOTDEV} == /dev/nvme0n1 ]]
+   then
+      echo "Skipping explicit pvcreate opertion... " 
+   else
+      pvcreate "${CHROOTDEV}${PARTPRE}2" || LogBrk 5 "PV creation failed. Aborting!"
+   fi
    vgcreate -y "${VGNAME}" "${CHROOTDEV}${PARTPRE}2" || LogBrk 5 "VG creation failed. Aborting!"
    lvcreate --yes -W y -L "${ROOTVOL[1]}" -n "${ROOTVOL[0]}" "${VGNAME}" || LVCSTAT=1
    lvcreate --yes -W y -L "${SWAPVOL[1]}" -n "${SWAPVOL[0]}" "${VGNAME}" || LVCSTAT=1
@@ -222,7 +228,7 @@ do
 done
 
 # See if our carve-target is an NVMe
-if [[ ${CHROOTDEV} =~ /dev/nvme ]]
+if [[ ${CHROOTDEV} =~ /dev/nvme0 ]]
 then
    PARTPRE="p"
 else

--- a/DiskSetup.sh
+++ b/DiskSetup.sh
@@ -228,7 +228,7 @@ do
 done
 
 # See if our carve-target is an NVMe
-if [[ ${CHROOTDEV} =~ /dev/nvme0 ]]
+if [[ ${CHROOTDEV} =~ /dev/nvme ]]
 then
    PARTPRE="p"
 else


### PR DESCRIPTION
Things seem to get henkie when you try to `pvcreate` on a disk that's had `pivot_root` run against it (break's spel's provisioner). Add a conditional to better-ensure that `pvcreate` is only called on a secondary EBS.