### PR TITLE
AWScliSetup.sh: Support for dedicated installation of AWS RPMs

### DIFF
--- a/AWScliSetup.sh
+++ b/AWScliSetup.sh
@@ -28,17 +28,18 @@ SYSTEMDSVCS=(
 check_AMZNRPMS()
 {
    # Make sure the AMZN.Linux packages are present
-      AMZNRPMS=($( stat -c '%n' "${SCRIPTROOT}"/AWSpkgs/*.el7.*.rpm))
-      if [[ ${#AMZNRPMS[@]} -eq 0 ]]
-      then
-         (
-         echo "AMZN.Linux packages not found in ${SCRIPTROOT}/AWSpkgs"
-         echo "Please download missing RPMs before proceeding."
-         echo "Note: GetAmznLx.sh may be used to do this for you."
-         echo "Aborting..."
-         ) > /dev/stderr
-         exit 1
-      fi
+   # shellcheck disable=SC2207
+   AMZNRPMS=($( stat -c '%n' "${SCRIPTROOT}"/AWSpkgs/*.el7.*.rpm))
+   if [[ ${#AMZNRPMS[@]} -eq 0 ]]
+   then
+      (
+      echo "AMZN.Linux packages not found in ${SCRIPTROOT}/AWSpkgs"
+      echo "Please download missing RPMs before proceeding."
+      echo "Note: GetAmznLx.sh may be used to do this for you."
+      echo "Aborting..."
+      ) > /dev/stderr
+      exit 1
+   fi
 }
 
 enable_rhel_optional()
@@ -51,7 +52,7 @@ enable_rhel_optional()
    fi
 
    # Enabled requested repos in chroot() environment
-   if [[ ! -z ${PRIVREPOS+xxx} ]]
+   if [[ -n ${PRIVREPOS+xxx} ]]
    then
       chroot "${CHROOT}" yum-config-manager --enable "${PRIVREPOS}"
    fi

--- a/AWScliSetup.sh
+++ b/AWScliSetup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # shellcheck disable=SC2086,SC2207,SC2236,SC2015
 #
 # Script to automate and standardize installation of AWScli tools
@@ -25,76 +25,100 @@ SYSTEMDSVCS=(
       ec2-instance-connect.service
    )
 
-# Make sure the AMZN.Linux packages are present
-AMZNRPMS=($( stat -c '%n' ${SCRIPTROOT}/AWSpkgs/*.el7.*.rpm))
-if [[ ${#AMZNRPMS[@]} -eq 0 ]]
-then
-   (
-    echo "AMZN.Linux packages not found in ${SCRIPTROOT}/AWSpkgs"
-    echo "Please download missing RPMs before proceeding."
-    echo "Note: GetAmznLx.sh may be used to do this for you."
-    echo "Aborting..."
-   ) > /dev/stderr
-   exit 1
-fi
+check_AMZNRPMS()
+{
+   # Make sure the AMZN.Linux packages are present
+      AMZNRPMS=($( stat -c '%n' "${SCRIPTROOT}"/AWSpkgs/*.el7.*.rpm))
+      if [[ ${#AMZNRPMS[@]} -eq 0 ]]
+      then
+         (
+         echo "AMZN.Linux packages not found in ${SCRIPTROOT}/AWSpkgs"
+         echo "Please download missing RPMs before proceeding."
+         echo "Note: GetAmznLx.sh may be used to do this for you."
+         echo "Aborting..."
+         ) > /dev/stderr
+         exit 1
+      fi
+}
 
-# Enable the RHEL "optional" repo where appropriate
-OPTIONREPO=$(yum repolist all | grep rhel-server-optional || true)
-if [[ ${OPTIONREPO} != "" ]]
-then
-   chroot "${CHROOT}" yum-config-manager --enable "${OPTIONREPO/\/*/}"
-fi
+enable_rhel_optional()
+{
+   # Enable the RHEL "optional" repo where appropriate
+   OPTIONREPO=$(yum repolist all | grep rhel-server-optional || true)
+   if [[ ${OPTIONREPO} != "" ]]
+   then
+      chroot "${CHROOT}" yum-config-manager --enable "${OPTIONREPO/\/*/}"
+   fi
 
-# Enabled requested repos in chroot() environment
-if [[ ! -z ${PRIVREPOS+xxx} ]]
-then
-    chroot "${CHROOT}" yum-config-manager --enable "${PRIVREPOS}"
-fi
+   # Enabled requested repos in chroot() environment
+   if [[ ! -z ${PRIVREPOS+xxx} ]]
+   then
+      chroot "${CHROOT}" yum-config-manager --enable "${PRIVREPOS}"
+   fi
+}
 
-# Bail if bogus location for ZIP
-printf "Fetching %s from ${ZIPSRC}..." "${BUNDLE}"
-(cd /tmp && curl -sL "${ZIPSRC}" -o "${BUNDLE}")
-echo
+install_awscli()
+{
+   # Bail if bogus location for ZIP
+   printf "Fetching %s from ${ZIPSRC}..." "${BUNDLE}"
+   (cd /tmp && curl -sL "${ZIPSRC}" -o "${BUNDLE}")
+   echo
 
-if [[ ! -f ${AWSZIP} ]]
-then
-   echo "Did not find software at ${AWSZIP}. Aborting..." > /dev/stderr
-   exit 1
-elif [[ $(file -b "${AWSZIP}" | cut -d " " -f 1) != Zip ]]
-then
-   echo "${AWSZIP} is not a ZIP-archive. Aborting..." > /dev/stderr
-   exit 1
-else
-   echo "Downloaded ${ZIPSRC} to ${AWSZIP}."
-fi
+   if [[ ! -f ${AWSZIP} ]]
+   then
+      echo "Did not find software at ${AWSZIP}. Aborting..." > /dev/stderr
+      exit 1
+   elif [[ $(file -b "${AWSZIP}" | cut -d " " -f 1) != Zip ]]
+   then
+      echo "${AWSZIP} is not a ZIP-archive. Aborting..." > /dev/stderr
+      exit 1
+   else
+      echo "Downloaded ${ZIPSRC} to ${AWSZIP}."
+   fi
 
-# Unzip the AWScli bundle into /tmp
-(cd /tmp && unzip -o ${AWSZIP})
+   # Unzip the AWScli bundle into /tmp
+   (cd /tmp && unzip -o ${AWSZIP})
 
-# Copy the de-archived zip to ${CHROOT}
-cp -r /tmp/awscli-bundle "${CHROOT}/root"
+   # Copy the de-archived zip to ${CHROOT}
+   cp -r /tmp/awscli-bundle "${CHROOT}/root"
 
-# Install AWScli bundle into ${CHROOT}
-chroot "${CHROOT}" /root/awscli-bundle/install -i /opt/aws/cli -b /usr/bin/aws
+   # Install AWScli bundle into ${CHROOT}
+   chroot "${CHROOT}" /root/awscli-bundle/install -i /opt/aws/cli -b /usr/bin/aws
 
-# Verify AWScli functionality within ${CHROOT}
-chroot "${CHROOT}" /usr/bin/aws --version
+   # Verify AWScli functionality within ${CHROOT}
+   chroot "${CHROOT}" /usr/bin/aws --version
 
-# Cleanup
-rm -rf "${CHROOT}/root/awscli-bundle"
+   # Cleanup
+   rm -rf "${CHROOT}/root/awscli-bundle"
+}
 
-# Depending on RPMs dependencies, this may fail if a repo is
-# missing (e.g. EPEL). Will also fail if no RPMs are present
-# in the search directory.
-{ STDERR=$(yum install -y "${EPELRELEASE}" 2>&1 1>&$out); } {out}>&1 || echo "$STDERR" | grep "Error: Nothing to do"
-{ STDERR=$(yum --installroot="${CHROOT}" install -y "${EPELRELEASE}" 2>&1 1>&$out); } {out}>&1 || echo "$STDERR" | grep "Error: Nothing to do"
-yum --installroot="${CHROOT}" install -y "${SCRIPTROOT}"/AWSpkgs/*.el7.*.rpm \
-   || exit $?
+enable_services()
+{
+   # Need to force systemd services to be enabled in resultant AMI
+   for SVC in "${SYSTEMDSVCS[@]}"
+   do
+      printf "Attempting to enable %s in %s... " "${SVC}" "${CHROOT}"
+      chroot "${CHROOT}" /usr/bin/systemctl enable "${SVC}" && echo "Success" || \
+      ( echo "FAILED" ; exit 1 )
+   done
 
-# Need to force systemd services to be enabled in resultant AMI
-for SVC in "${SYSTEMDSVCS[@]}"
-do
-   printf "Attempting to enable %s in %s... " "${SVC}" "${CHROOT}"
-   chroot "${CHROOT}" /usr/bin/systemctl enable "${SVC}" && echo "Success" || \
-     ( echo "FAILED" ; exit 1 )
-done
+}
+
+install_awstools()
+{
+   # Depending on RPMs dependencies, this may fail if a repo is
+   # missing (e.g. EPEL). Will also fail if no RPMs are present
+   # in the search directory.
+   { STDERR=$(yum install -y "${EPELRELEASE}" 2>&1 1>&$out); } {out}>&1 || echo "$STDERR" | grep "Error: Nothing to do"
+   { STDERR=$(yum --installroot="${CHROOT}" install -y "${EPELRELEASE}" 2>&1 1>&$out); } {out}>&1 || echo "$STDERR" | grep "Error: Nothing to do"
+   yum --installroot="${CHROOT}" install -y "${SCRIPTROOT}"/AWSpkgs/*.el7.*.rpm \
+      || exit $?
+
+   enable_services
+}
+
+
+check_AMZNRPMS
+enable_rhel_optional
+install_awscli
+install_awstools

--- a/AWScliSetup.sh
+++ b/AWScliSetup.sh
@@ -134,8 +134,9 @@ install_awstools()
    then
       echo "No Installation of addional Amazon RPMs"
    else
-      yum info epel-release >/dev/null 2>&1 || yum install -y "${EPELRELEASE}" 
-      (yum --installroot="${CHROOT}" info epel-release >/dev/null 2>&1) ||  yum --installroot="${CHROOT}" install -y "${EPELRELEASE}" 
+      epelpkgname=$(rpm -qp --qf "%{NAME}\n" "${EPELRELEASE}" )
+      yum info "$epelpkgname" >/dev/null 2>&1 || yum install -y "${EPELRELEASE}" 
+      (yum --installroot="${CHROOT}" info "$epelpkgname" >/dev/null 2>&1) ||  yum --installroot="${CHROOT}" install -y "${EPELRELEASE}" 
       # shellcheck disable=2086
       yum --installroot="${CHROOT}" install -e 0 -y ${rpmfiles} \
          || exit $?

--- a/AWScliSetup.sh
+++ b/AWScliSetup.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2086,SC2207,SC2236,SC2015
 #
 # Script to automate and standardize installation of AWScli tools
 #
@@ -11,6 +10,7 @@
 # package, or it will default to one publicly available.
 #
 ############################################################
+# shellcheck disable=SC2086
 SCRIPTROOT="$(dirname ${0})"
 CHROOT="${CHROOT:-/mnt/ec2-root}"
 BUNDLE="awscli-bundle.zip"
@@ -100,6 +100,7 @@ enable_services()
       if [ -f "${CHROOT}/etc/systemd/system/$SVC" ]
       then
          printf "Attempting to enable %s in %s... " "${SVC}" "${CHROOT}"
+         # shellcheck disable=SC2015
          chroot "${CHROOT}" /usr/bin/systemctl enable "${SVC}" && echo "Success" || \
          ( echo "FAILED" ; exit 1 )
       fi
@@ -110,11 +111,10 @@ get_awstools_filenames()
 {
    if [ "${AWSTOOLSRPM:-""}" = "" ]
    then
-      # shellcheck disable=2046
-      echo $(ls "${SCRIPTROOT}"/AWSpkgs/*.el7.*.rpm)
+      ls "${SCRIPTROOT}"/AWSpkgs/*.el7.*.rpm
    else
       rpmfiles=""
-      for rpmfile in $(echo "$AWSTOOLSRPM")
+      for rpmfile in ${AWSTOOLSRPM}
       do
          rpmfiles="${rpmfiles} "$(ls "${SCRIPTROOT}/AWSpkgs/${rpmfile}"*.el7.*.rpm)
       done

--- a/AWScliSetup.sh
+++ b/AWScliSetup.sh
@@ -97,11 +97,13 @@ enable_services()
    # Need to force systemd services to be enabled in resultant AMI
    for SVC in "${SYSTEMDSVCS[@]}"
    do
-      printf "Attempting to enable %s in %s... " "${SVC}" "${CHROOT}"
-      chroot "${CHROOT}" /usr/bin/systemctl enable "${SVC}" && echo "Success" || \
-      ( echo "FAILED" ; exit 1 )
+      if [ -f "${CHROOT}/etc/systemd/system/$SVC" ]
+      then
+         printf "Attempting to enable %s in %s... " "${SVC}" "${CHROOT}"
+         chroot "${CHROOT}" /usr/bin/systemctl enable "${SVC}" && echo "Success" || \
+         ( echo "FAILED" ; exit 1 )
+      fi
    done
-
 }
 
 install_awstools()


### PR DESCRIPTION
The script has been refactored for suppoting the installation of dedicated RPMs from an environment variable.

The commits are splitted to show the changes and enhancements. A support for setting the list of RPMs with parameters during execution is planned for a later time.