### PR TITLE
CleanChroot.sh: MAINTUSR could be configured by environment variable

### DIFF
--- a/CleanChroot.sh
+++ b/CleanChroot.sh
@@ -7,7 +7,7 @@
 CHROOT=${CHROOT:-/mnt/ec2-root}
 CLOUDCFG="$CHROOT/etc/cloud/cloud.cfg"
 JRNLCNF="$CHROOT/etc/systemd/journald.conf"
-MAINTUSR="maintuser"
+MAINTUSR=${MAINTUSR:-"maintuser"}
 
 # Disable EPEL repos
 chroot "${CHROOT}" yum-config-manager --disable "*epel*" > /dev/null
@@ -56,7 +56,7 @@ sed -i '/^system_info/,/^  ssh_svcname/d' "${CLOUDCFG}"
 sed -i '/syntax=yaml/i\
 system_info:\
   default_user:\
-    name: maintuser\
+    name: '"${MAINTUSR}"'\
     lock_passwd: true\
     gecos: Local Maintenance User\
     groups: [wheel, adm]\


### PR DESCRIPTION
The maintuser was hard coded in CleanChroot.sh. The user could be set with the following variable:

`export MAINTUSR=ec2-user`