### PR TITLE
Address unbound var errors

### DIFF
--- a/AWScliSetup.sh
+++ b/AWScliSetup.sh
@@ -105,7 +105,7 @@ enable_services()
 
 get_awstools_filenames()
 {
-   if [[ -z ${AWSTOOLSRPM} ]]
+   if [[ -z ${AWSTOOLSRPM:-} ]]
    then
       ls "${SCRIPTROOT}"/AWSpkgs/*.el7.*.rpm
    else

--- a/Umount.sh
+++ b/Umount.sh
@@ -7,7 +7,7 @@ CHROOT="${CHROOT:-/mnt/ec2-root}"
 
 while read -r BLK
 do
-   if [[ ${DEBUG} == true ]]
+   if [[ ${DEBUG:-} == true ]]
    then
       echo "umount: $BLK"
    fi


### PR DESCRIPTION
A couple vars in recent PRs are unbound during default run-profiles. This PR fixes that (validated with spel-ci)