### PR TITLE
Excludes firmware pkg detected on rhel7

### DIFF
--- a/ChrootBuild.sh
+++ b/ChrootBuild.sh
@@ -394,6 +394,7 @@ EXCLUDE_PKGS=(
     -iwl6000g2b-firmware
     -iwl6050-firmware
     -iwl7260-firmware
+    -iwl7265-firmware
     -libertas-sd8686-firmware
     -libertas-sd8787-firmware
     -libertas-usb8388-firmware


### PR DESCRIPTION
Failures appear to be caused by an obselete marker, since the
required pkg `iwl7260-firmware` is already excluded

```
    minimal-rhel-7-hvm: Package iwl7265-firmware is obsoleted by iwl7260-firmware, trying to install iwl7260-firmware-25.30.13.0-76.el7.noarch instead
```