### PR TITLE
Add ability to bake in a root password

### DIFF
--- a/Docs/README_PrivateRun.md
+++ b/Docs/README_PrivateRun.md
@@ -19,6 +19,13 @@ The primary expected use case for these scripts is in a network that is able to 
       ./GrubSetup.sh /dev/xvdf ; \
       ./NetSet.sh ; \
       ./CleanChroot.sh ; \
+~~~
+Optionally, run:
+~~~
+      ./SetRootPW.sh <PASSWORD_STRING>; \
+~~~
+If setting the root user's password is desired. This will typically be used in non-cloud environments (e.g., VMware vSphers)
+~~~
       ./PreRelabel.sh	 ; \
       ./Umount.sh
 ~~~

--- a/Docs/README_PrivateRun.md
+++ b/Docs/README_PrivateRun.md
@@ -24,7 +24,7 @@ Optionally, run:
 ~~~
       ./SetRootPW.sh <PASSWORD_STRING>; \
 ~~~
-If setting the root user's password is desired. This will typically be used in non-cloud environments (e.g., VMware vSphers)
+If setting the root user's password is desired. This will typically be used in non-cloud environments (e.g., VMware vSphere)
 ~~~
       ./PreRelabel.sh	 ; \
       ./Umount.sh

--- a/Docs/README_PublicRun.md
+++ b/Docs/README_PublicRun.md
@@ -19,6 +19,13 @@ The primary expected use case for these scripts is in a network that is able to 
       ./GrubSetup.sh /dev/xvdf ; \
       ./NetSet.sh ; \
       ./CleanChroot.sh ; \
+~~~
+Optionally, run:
+~~~
+      ./SetRootPW.sh <PASSWORD_STRING>; \
+~~~
+If setting the root user's password is desired. This will typically be used in non-cloud environments (e.g., VMware vSphers)
+~~~
       ./PreRelabel.sh	 ; \
       ./Umount.sh
 ~~~

--- a/MkChrootTree.sh
+++ b/MkChrootTree.sh
@@ -193,6 +193,8 @@ BINDSOURCES=( $(grep -v "${ALTROOT}" /proc/mounts | sed '{
                  /^none/d
                  /\/tmp/d
                  /rootfs/d
+		 /\/ /d
+		 /\/boot /d
                  /dev\/xvd/d
                  /dev\/nvme/d
                  /\/user\//d

--- a/MkChrootTree.sh
+++ b/MkChrootTree.sh
@@ -193,8 +193,8 @@ BINDSOURCES=( $(grep -v "${ALTROOT}" /proc/mounts | sed '{
                  /^none/d
                  /\/tmp/d
                  /rootfs/d
-		 /\/ /d
-		 /\/boot /d
+                 /\/ /d
+                 /\/boot /d
                  /dev\/xvd/d
                  /dev\/nvme/d
                  /\/user\//d

--- a/SetRootPW.sh
+++ b/SetRootPW.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# set -euo pipefail
+#
+# shellcheck disable=SC2015
+#
+# Simple script to enable maintenance-login before sealing up the template
+#
+######################################################################
+PROGNAME="$( basename "${0}" )"
+CHROOT="${CHROOT:-/mnt/ec2-root}"
+ROOTPWSTRING="${PWSTRING:-UNDEF}"
+MAINTUSER="${MAINTUSER:-root}"
+
+
+# Error handler function
+function err_exit {
+   local ERRSTR
+   local ISNUM
+   local SCRIPTEXIT
+
+   ERRSTR="${1}"
+   ISNUM='^[0-9]+$'
+   SCRIPTEXIT="${2:-1}"
+
+   if [[ ${DEBUG} == true ]]
+   then
+      # Our output channels
+      logger -i -t "${PROGNAME}" -p kern.crit -s -- "${ERRSTR}"
+   else
+      logger -i -t "${PROGNAME}" -p kern.crit -- "${ERRSTR}"
+   fi
+
+   # Only exit if requested exit is numerical
+   if [[ ${SCRIPTEXIT} =~ ${ISNUM} ]]
+   then
+      exit "${SCRIPTEXIT}"
+   fi
+}
+
+# Print out a basic usage message
+function UsageMsg {
+   local SCRIPTEXIT
+   local PART
+   SCRIPTEXIT="${1:-1}"
+
+   (
+      echo "Usage: ${0} [GNU long option] [option] ..."
+      echo "  Options:"
+      printf '\t%-4s%s\n' '-h' 'Print this message'
+      printf '\t%-4s%s\n' '-m' 'Template maintenance user (default: "root")'
+      printf '\t%-4s%s\n' '-p' 'Password to assign to template maintenance user'
+      printf '\t%-6s%s\n' '' 'Default layout:'
+      for PART in ${DEFGEOMARR[*]}
+      do
+         printf '\t%-8s%s\n' '' "${PART}"
+      done
+      echo "  GNU long options:"
+      printf '\t%-20s%s\n' '--help' 'See "-h" short-option'
+      printf '\t%-20s%s\n' '--maintuser' 'See "-m" short-option'
+      printf '\t%-20s%s\n' '--password' 'See "-p" short-option'
+   )
+   exit "${SCRIPTEXIT}"
+}
+
+function SetPassString {
+   printf "Setting password for %... " "${MAINTUSER}"
+   echo "${ROOTPWSTRING}" | chroot "${CHROOT}" /bin/passwd --stdin "${MAINTUSER}" && \
+     echo "Success" || err_exit "Failed setting password for ${MAINTUSER}" 1
+
+}
+
+function AllowRootSsh {
+   local SSHDCFGFILE
+   local CFGITEM
+
+   SSHDCFGFILE="/etc/ssh/sshd_config"
+   CFGITEM="PermitRootLogin"
+
+   printf "Allow remote-login for root... "
+   if [[ $( grep -q "^${CFGITEM}" "${SSHDCFGFILE}" )$? -eq 0 ]]
+   then
+      sed "/^${CFGITEM}/s/[ 	][ 	]*.*$/ yes/" "${SSHDCFGFILE}" && \
+        err_exit "Change ${CFGITEM} value in ${SSHDCFGFILE}" 0 || \
+        err_exit "Failed changing ${CFGITEM} value in ${SSHDCFGFILE}" 1
+   else
+      echo "PermitRootLogin yes" > "${SSHDCFGFILE}" && \
+        err_exit "Added ${CFGITEM} to ${SSHDCFGFILE}" 0 || \
+        err_exit "Failed adding ${CFGITEM} to ${SSHDCFGFILE}" 1
+   fi
+}
+
+
+
+######################
+## Main program-flow
+######################
+OPTIONBUFR=$(getopt -o hm:p: --long help,maintuser:,password: -n "${PROGNAME}" -- "$@")
+
+eval set -- "${OPTIONBUFR}"
+
+###################################
+# Parse contents of ${OPTIONBUFR}
+###################################
+while true
+do
+   case "$1" in
+      -h|--help)
+         UsageMsg 0
+         ;;
+      -m|--maintuser)
+         case "$2" in
+            "")
+               err_exit "Error: option required but not specified" 1
+               shift 2;
+               exit 1
+               ;;
+            *)
+               MAINTUSER=${2}
+               shift 2;
+               ;;
+         esac
+         ;;
+      -p|--password)
+         case "$2" in
+            "")
+               err_exit "Error: option required but not specified" 1
+               shift 2;
+               exit 1
+               ;;
+            *)
+               ROOTPWSTRING=${2}
+               shift 2;
+               ;;
+         esac
+         ;;
+      --)
+         shift
+         break
+         ;;
+      *)
+         err_exit "Internal error!"
+         exit 1
+         ;;
+   esac
+done
+
+
+# Exit if password not passed
+if [[ ${ROOTPWSTRING} == UNDEF ]]
+then
+   err_exit "No password string passed to script. ABORTING!" 1
+else
+   SetPassString
+fi
+
+# Update sshd_config as necessary
+if [[ ${MAINTUSER} == root ]]
+then
+   AllowRootSsh
+fi

--- a/SetRootPW.sh
+++ b/SetRootPW.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-# set -euo pipefail
-#
-# shellcheck disable=SC2015
 #
 # Simple script to enable maintenance-login before sealing up the template
 #
@@ -77,7 +74,6 @@ function SetPassString {
    echo "${ROOTPWSTRING}" | chroot "${CHROOT}" /bin/passwd --stdin "${MAINTUSER}" || \
       err_exit "Failed setting password for ${MAINTUSER}" 1
    echo "Success"
-     echo "Success" || err_exit "Failed setting password for ${MAINTUSER}" 1
 
    # Probably superfluous w/in a function...
    if [[ ${PROTECTPWLOGGING:-} == "TRUE" ]]
@@ -112,14 +108,15 @@ function EnableProvUser {
    # Create maintenance user
    printf 'Creating %s in chroot [%s]... ' "${MAINTUSER}" "${CHROOT}"
    chroot "${CHROOT}" useradd -c "Maintenance User Account" -m \
-     -s /bin/bash "${MAINTUSER}" && echo "Success!" || \
-     err_exit "Failed creating ${MAINTUSER}" 1
+     -s /bin/bash "${MAINTUSER}" || err_exit "Failed creating ${MAINTUSER}" 1
+   echo "Success!"
 
    # Give maintenance user privileges
    printf 'Adding %s to sudoers... ' "${MAINTUSER}"
    printf '%s\tALL=(ALL)\tNOPASSWD:ALL\n' "${MAINTUSER}" > \
-     "${CHROOT}/etc/sudoers.d/user_${MAINTUSER}" && echo "Success!" || \
+     "${CHROOT}/etc/sudoers.d/user_${MAINTUSER}" || \
      err_exit "Failed adding ${MAINTUSER} to sudoers" 1
+   echo "Success!"
 
    # Set password
    SetPassString

--- a/SetRootPW.sh
+++ b/SetRootPW.sh
@@ -63,11 +63,27 @@ function UsageMsg {
 }
 
 function SetPassString {
+   local PROTECTPWLOGGING
+
+   # Suppress trace-logging (if tracing is set)
+   if [[ $- =~ "x" ]]
+   then
+      PROTECTPWLOGGING=TRUE
+      set +x
+   fi
+
+   # Set password for the selected user 
    printf "Setting password for %s... " "${MAINTUSER}"
    echo "${ROOTPWSTRING}" | chroot "${CHROOT}" /bin/passwd --stdin "${MAINTUSER}" || \
       err_exit "Failed setting password for ${MAINTUSER}" 1
    echo "Success"
      echo "Success" || err_exit "Failed setting password for ${MAINTUSER}" 1
+
+   # Probably superfluous w/in a function...
+   if [[ ${PROTECTPWLOGGING:-} == "TRUE" ]]
+   then
+      set -x
+   fi
 
 }
 

--- a/SetRootPW.sh
+++ b/SetRootPW.sh
@@ -79,13 +79,13 @@ function AllowRootSsh {
    printf "Allow remote-login for root... "
    if [[ $( grep -q "^${CFGITEM}" "${SSHDCFGFILE}" )$? -eq 0 ]]
    then
-      sed -i "/^${CFGITEM}/s/[ 	][ 	]*.*$/ yes/" "${SSHDCFGFILE}" && \
-        echo "Change ${CFGITEM} value in ${SSHDCFGFILE}" 0 || \
+      sed -i "/^${CFGITEM}/s/[ 	][ 	]*.*$/ yes/" "${SSHDCFGFILE}" || \
         err_exit "Failed changing ${CFGITEM} value in ${SSHDCFGFILE}" 1
+      echo "Change ${CFGITEM} value in ${SSHDCFGFILE}"
    else
-      echo "PermitRootLogin yes" > "${SSHDCFGFILE}" && \
-        echo "Added ${CFGITEM} to ${SSHDCFGFILE}" 0 || \
+      echo "PermitRootLogin yes" > "${SSHDCFGFILE}" || \
         err_exit "Failed adding ${CFGITEM} to ${SSHDCFGFILE}" 1
+      echo "Added ${CFGITEM} to ${SSHDCFGFILE}"
    fi
 }
 

--- a/SetRootPW.sh
+++ b/SetRootPW.sh
@@ -63,7 +63,7 @@ function UsageMsg {
 }
 
 function SetPassString {
-   printf "Setting password for %... " "${MAINTUSER}"
+   printf "Setting password for %s... " "${MAINTUSER}"
    echo "${ROOTPWSTRING}" | chroot "${CHROOT}" /bin/passwd --stdin "${MAINTUSER}" && \
      echo "Success" || err_exit "Failed setting password for ${MAINTUSER}" 1
 
@@ -73,18 +73,18 @@ function AllowRootSsh {
    local SSHDCFGFILE
    local CFGITEM
 
-   SSHDCFGFILE="/etc/ssh/sshd_config"
+   SSHDCFGFILE="${CHROOT}/etc/ssh/sshd_config"
    CFGITEM="PermitRootLogin"
 
    printf "Allow remote-login for root... "
    if [[ $( grep -q "^${CFGITEM}" "${SSHDCFGFILE}" )$? -eq 0 ]]
    then
-      sed "/^${CFGITEM}/s/[ 	][ 	]*.*$/ yes/" "${SSHDCFGFILE}" && \
-        err_exit "Change ${CFGITEM} value in ${SSHDCFGFILE}" 0 || \
+      sed -i "/^${CFGITEM}/s/[ 	][ 	]*.*$/ yes/" "${SSHDCFGFILE}" && \
+        echo "Change ${CFGITEM} value in ${SSHDCFGFILE}" 0 || \
         err_exit "Failed changing ${CFGITEM} value in ${SSHDCFGFILE}" 1
    else
       echo "PermitRootLogin yes" > "${SSHDCFGFILE}" && \
-        err_exit "Added ${CFGITEM} to ${SSHDCFGFILE}" 0 || \
+        echo "Added ${CFGITEM} to ${SSHDCFGFILE}" 0 || \
         err_exit "Failed adding ${CFGITEM} to ${SSHDCFGFILE}" 1
    fi
 }

--- a/SetRootPW.sh
+++ b/SetRootPW.sh
@@ -64,7 +64,9 @@ function UsageMsg {
 
 function SetPassString {
    printf "Setting password for %s... " "${MAINTUSER}"
-   echo "${ROOTPWSTRING}" | chroot "${CHROOT}" /bin/passwd --stdin "${MAINTUSER}" && \
+   echo "${ROOTPWSTRING}" | chroot "${CHROOT}" /bin/passwd --stdin "${MAINTUSER}" || \
+      err_exit "Failed setting password for ${MAINTUSER}" 1
+   echo "Success"
      echo "Success" || err_exit "Failed setting password for ${MAINTUSER}" 1
 
 }


### PR DESCRIPTION
In order to better support on-premises virtualization-solutions (e.g. VMware vSphere), add the ability to inject a fixed-password for either the root or "break glass" user accounts.