### PR TITLE
renaming CHROOT to AMIGENCHROOT to use the renamed variable exported from amigen7 script

### DIFF
--- a/AWScliSetup.sh
+++ b/AWScliSetup.sh
@@ -12,7 +12,7 @@
 #
 ############################################################
 SCRIPTROOT="$( dirname "${0}" )"
-CHROOT="${CHROOT:-/mnt/ec2-root}"
+CHROOT="${AMIGENCHROOT:-/mnt/ec2-root}"
 BUNDLE="awscli-bundle.zip"
 ZIPSRC="${1:-https://s3.amazonaws.com/aws-cli/awscli-bundle.zip}"
 EPELRELEASE="${2:-https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm}"

--- a/AWSutils.sh
+++ b/AWSutils.sh
@@ -5,7 +5,7 @@ set -eu -o pipefail
 #
 #######################################################################
 PROGNAME=$(basename "$0")
-CHROOTMNT="${CHROOT:-/mnt/ec2-root}"
+CHROOTMNT="${AMIGENCHROOT:-/mnt/ec2-root}"
 CLIV1SOURCE="${CLIV1SOURCE:-UNDEF}"
 CLIV2SOURCE="${CLIV2SOURCE:-UNDEF}"
 ICONNECTSRC="${ICONNECTSRC:-UNDEF}"

--- a/ChrootBuild.sh
+++ b/ChrootBuild.sh
@@ -5,7 +5,7 @@
 #
 #####################################
 PROGNAME=$(basename "$0")
-CHROOT="${CHROOT:-/mnt/ec2-root}"
+CHROOT="${AMIGENCHROOT:-/mnt/ec2-root}"
 
 case $( rpm -qf /etc/os-release --qf '%{name}' ) in
    centos-release)

--- a/ChrootCfg.sh
+++ b/ChrootCfg.sh
@@ -15,7 +15,7 @@
 #   location.
 #
 #####################################
-CHROOT="${CHROOT:-/mnt/ec2-root}"
+CHROOT="${AMIGENCHROOT:-/mnt/ec2-root}"
 EXECIT=${LOCALSCRIPT:-UNDEF}
 NTPCONF="${CHROOT}/etc/ntp.conf"
 CLOUDCF="${CHROOT}/etc/cloud/cloud.cfg"

--- a/CleanChroot.sh
+++ b/CleanChroot.sh
@@ -4,7 +4,7 @@
 # Do some file cleanup...
 #
 #########################
-CHROOT=${CHROOT:-/mnt/ec2-root}
+CHROOT=${AMIGENCHROOT:-/mnt/ec2-root}
 CLOUDCFG="$CHROOT/etc/cloud/cloud.cfg"
 JRNLCNF="$CHROOT/etc/systemd/journald.conf"
 MAINTUSR=${MAINTUSR:-"maintuser"}

--- a/GrubSetup.sh
+++ b/GrubSetup.sh
@@ -6,7 +6,7 @@
 #   top of.
 #
 #################################################################
-CHROOT="${CHROOT:-/mnt/ec2-root}"
+CHROOT="${AMIGENCHROOT:-/mnt/ec2-root}"
 CHROOTDEV=${1:-UNDEF}
 CHGRUBDEF="${CHROOT}/etc/default/grub"
 FIPSDISABLE="${FIPSDISABLE:-UNDEF}"

--- a/MkChrootTree.sh
+++ b/MkChrootTree.sh
@@ -6,7 +6,7 @@
 #
 #######################################################################
 CHROOTDEV=${1:-UNDEF}
-ALTROOT="${CHROOT:-/mnt/ec2-root}"
+ALTROOT="${AMIGENCHROOT:-/mnt/ec2-root}"
 DEVFSTYP="${2:-ext4}"
 GEOMETRYSTRING="${3:-/:rootVol:4,swap:swapVol:2,/home:homeVol:1,/var:varVol:2,/var/log:logVol:2,/var/log/audit:auditVol:100%FREE}"
 

--- a/MkTabs.sh
+++ b/MkTabs.sh
@@ -4,7 +4,7 @@
 # Script to set up the chroot'ed /etc/fstab
 #
 #################################################################
-CHROOT="${CHROOT:-/mnt/ec2-root}"
+CHROOT="${AMIGENCHROOT:-/mnt/ec2-root}"
 TARGSWAP=${2:-/dev/VolGroup00/swapVol}
 FSTAB="${CHROOT}/etc/fstab"
 

--- a/NetSet.sh
+++ b/NetSet.sh
@@ -6,7 +6,7 @@
 # * Configure basic SSHD behavior
 #
 #################################################################
-CHROOT="${CHROOT:-/mnt/ec2-root}"
+CHROOT="${AMIGENCHROOT:-/mnt/ec2-root}"
 
 # Create default if-script
 cat <<EOF > "${CHROOT}/etc/sysconfig/network-scripts/ifcfg-eth0"

--- a/PreRelabel.sh
+++ b/PreRelabel.sh
@@ -7,7 +7,7 @@
 # reducing the launch-to-ready time by several minutes.
 #
 #################################################################
-CHROOT="${CHROOT:-/mnt/ec2-root}"
+CHROOT="${AMIGENCHROOT:-/mnt/ec2-root}"
 LOGGERFACILITY="local0"
 LOGGERLEVEL="crit"
 LOGGEROUT="${LOGGERFACILITY}.${LOGGERLEVEL}"

--- a/Umount.sh
+++ b/Umount.sh
@@ -3,7 +3,7 @@
 # Script to clean up all devices mounted under $CHROOT
 #
 #################################################################
-CHROOT="${CHROOT:-/mnt/ec2-root}"
+CHROOT="${AMIGENCHROOT:-/mnt/ec2-root}"
 
 while read -r BLK
 do


### PR DESCRIPTION
The CHROOT variable which was updated to AMIGENCHROOT is exported from the amigen7.sh script and therefore needed to be updated globally in AMIgen7