### PR TITLE
Replacing how REPOSRPM and EXTRARPMS is parsed

### DIFF
--- a/ChrootBuild.sh
+++ b/ChrootBuild.sh
@@ -129,7 +129,7 @@ function PrepChroot() {
       --installroot="${CHROOT}" -y install yum-utils
 
    # if alt-repo defined, disable everything, then install alt-repos
-   if [[ ! -z ${REPORPMS+xxx} ]]
+   if [[ -n ${REPORPMS+xxx} ]]
    then
       for RPM in "${REPORPMS[@]}"
       do
@@ -425,7 +425,7 @@ $YUMDO -- "${INCLUDE_PKGS[@]}" "${EXCLUDE_PKGS[@]}"
 rpm --root "${CHROOT}" -q "${INCLUDE_PKGS[@]}"
 
 # Install additionally-requested RPMs
-if [[ ! -z ${EXTRARPMS+xxx} ]]
+if [[ -n ${EXTRARPMS+xxx} ]]
 then
    printf "##########\n## Installing requested RPMs/groups\n##########\n"
    for RPM in "${EXTRARPMS[@]}"

--- a/ChrootBuild.sh
+++ b/ChrootBuild.sh
@@ -129,7 +129,7 @@ function PrepChroot() {
       --installroot="${CHROOT}" -y install yum-utils
 
    # if alt-repo defined, disable everything, then install alt-repos
-   if [[ -n ${REPORPMS} ]]
+   if [[ -n ${REPORPMS[0]} ]]
    then
       for RPM in "${REPORPMS[@]}"
       do
@@ -158,7 +158,7 @@ do
 	       exit 1
 	       ;;
 	    *)
-	       REPORPMS=(read -a "${2//,/ }")
+	       REPORPMS=$(read -a "${2//,/ }")
 	       shift 2;
 	       ;;
 	 esac
@@ -232,7 +232,7 @@ done
 # Stage useable repo-defs into $CHROOT/etc/yum.repos.d
 PrepChroot
 
-if [[ -n ${BONUSREPO} ]]
+if [[ -n ${BONUSREPO[0]} ]]
 then
    ENABREPO=--enablerepo=${BONUSREPO}
    # shellcheck disable=SC2125
@@ -425,7 +425,7 @@ $YUMDO -- "${INCLUDE_PKGS[@]}" "${EXCLUDE_PKGS[@]}"
 rpm --root "${CHROOT}" -q "${INCLUDE_PKGS[@]}"
 
 # Install additionally-requested RPMs
-if [[ -n ${EXTRARPMS} ]]
+if [[ -n ${EXTRARPMS[0]} ]]
 then
    printf "##########\n## Installing requested RPMs/groups\n##########\n"
    for RPM in "${EXTRARPMS[@]}"

--- a/ChrootBuild.sh
+++ b/ChrootBuild.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2005,SC2001,SC2181,SC2207,SC2236
 #
 # Install minimal RPM-set into chroot
 #

--- a/ChrootBuild.sh
+++ b/ChrootBuild.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2005,SC2001,SC2181,SC2207,SC2236
 #
 # Install minimal RPM-set into chroot
 #

--- a/ChrootBuild.sh
+++ b/ChrootBuild.sh
@@ -129,7 +129,7 @@ function PrepChroot() {
       --installroot="${CHROOT}" -y install yum-utils
 
    # if alt-repo defined, disable everything, then install alt-repos
-   if [[ -n ${REPORPMS[0]} ]]
+   if [[ -n "$REPORPMS" ]]
    then
       for RPM in "${REPORPMS[@]}"
       do
@@ -158,7 +158,7 @@ do
 	       exit 1
 	       ;;
 	    *)
-	       REPORPMS=$(read -a "${2//,/ }")
+	       IFS=, read -a REPORPMS <<< "$2"
 	       shift 2;
 	       ;;
 	 esac
@@ -184,7 +184,7 @@ do
 	       exit 1
 	       ;;
 	    *)
-	       EXTRARPMS=(read -a "${2//,/ }")
+	       IFS=, read -a EXTRARPMS <<< "$2"
 	       shift 2;
 	       ;;
 	 esac
@@ -232,7 +232,7 @@ done
 # Stage useable repo-defs into $CHROOT/etc/yum.repos.d
 PrepChroot
 
-if [[ -n ${BONUSREPO[0]} ]]
+if [[ -n "$BONUSREPO" ]]
 then
    ENABREPO=--enablerepo=${BONUSREPO}
    # shellcheck disable=SC2125
@@ -425,7 +425,7 @@ $YUMDO -- "${INCLUDE_PKGS[@]}" "${EXCLUDE_PKGS[@]}"
 rpm --root "${CHROOT}" -q "${INCLUDE_PKGS[@]}"
 
 # Install additionally-requested RPMs
-if [[ -n ${EXTRARPMS[0]} ]]
+if [[ -n "$EXTRARPMS" ]]
 then
    printf "##########\n## Installing requested RPMs/groups\n##########\n"
    for RPM in "${EXTRARPMS[@]}"

--- a/ChrootBuild.sh
+++ b/ChrootBuild.sh
@@ -129,7 +129,7 @@ function PrepChroot() {
       --installroot="${CHROOT}" -y install yum-utils
 
    # if alt-repo defined, disable everything, then install alt-repos
-   if [[ -n "$REPORPMS" ]]
+   if [[ -n ${REPORPMS[*]} ]]
    then
       for RPM in "${REPORPMS[@]}"
       do
@@ -158,7 +158,7 @@ do
 	       exit 1
 	       ;;
 	    *)
-	       IFS=, read -a REPORPMS <<< "$2"
+	       IFS=, read -ra REPORPMS <<< "$2"
 	       shift 2;
 	       ;;
 	 esac
@@ -184,7 +184,7 @@ do
 	       exit 1
 	       ;;
 	    *)
-	       IFS=, read -a EXTRARPMS <<< "$2"
+	       IFS=, read -ra EXTRARPMS <<< "$2"
 	       shift 2;
 	       ;;
 	 esac
@@ -425,7 +425,7 @@ $YUMDO -- "${INCLUDE_PKGS[@]}" "${EXCLUDE_PKGS[@]}"
 rpm --root "${CHROOT}" -q "${INCLUDE_PKGS[@]}"
 
 # Install additionally-requested RPMs
-if [[ -n "$EXTRARPMS" ]]
+if [[ -n ${EXTRARPMS[*]} ]]
 then
    printf "##########\n## Installing requested RPMs/groups\n##########\n"
    for RPM in "${EXTRARPMS[@]}"

--- a/ChrootBuild.sh
+++ b/ChrootBuild.sh
@@ -118,7 +118,7 @@ function PrepChroot() {
    rpm --root "${CHROOT}" -ivh --nodeps /tmp/*.rpm
 
    # When we don't specify repos, default to a sensible value-list
-   if [[ -z ${BONUSREPO+xxx} ]]
+   if [[ -z ${BONUSREPO} ]]
    then
       BONUSREPO=${DEFAULTREPOS}
    fi
@@ -129,7 +129,7 @@ function PrepChroot() {
       --installroot="${CHROOT}" -y install yum-utils
 
    # if alt-repo defined, disable everything, then install alt-repos
-   if [[ -n ${REPORPMS+xxx} ]]
+   if [[ -n ${REPORPMS} ]]
    then
       for RPM in "${REPORPMS[@]}"
       do
@@ -232,7 +232,7 @@ done
 # Stage useable repo-defs into $CHROOT/etc/yum.repos.d
 PrepChroot
 
-if [[ ! -z ${BONUSREPO+xxx} ]]
+if [[ -n ${BONUSREPO} ]]
 then
    ENABREPO=--enablerepo=${BONUSREPO}
    # shellcheck disable=SC2125
@@ -258,7 +258,7 @@ esac
 # Setup the "include" package list
 
 # Use manifest file if found and non-empty
-if [[ ! -z ${MANIFESTFILE} ]] && [[ -s ${MANIFESTFILE} ]]
+if [[ -n ${MANIFESTFILE} ]] && [[ -s ${MANIFESTFILE} ]]
 then
    echo "Selecting packages from ${MANIFESTFILE}..."
    INCLUDE_PKGS=($( < "${MANIFESTFILE}" ))
@@ -425,7 +425,7 @@ $YUMDO -- "${INCLUDE_PKGS[@]}" "${EXCLUDE_PKGS[@]}"
 rpm --root "${CHROOT}" -q "${INCLUDE_PKGS[@]}"
 
 # Install additionally-requested RPMs
-if [[ -n ${EXTRARPMS+xxx} ]]
+if [[ -n ${EXTRARPMS} ]]
 then
    printf "##########\n## Installing requested RPMs/groups\n##########\n"
    for RPM in "${EXTRARPMS[@]}"

--- a/ChrootBuild.sh
+++ b/ChrootBuild.sh
@@ -158,7 +158,7 @@ do
 	       exit 1
 	       ;;
 	    *)
-	       REPORPMS=($(echo "${2}" | sed 's/,/ /g'))
+	       REPORPMS=(read -a "${2//,/ }")
 	       shift 2;
 	       ;;
 	 esac
@@ -184,7 +184,7 @@ do
 	       exit 1
 	       ;;
 	    *)
-	       EXTRARPMS=($(echo "${2}" | sed 's/,/ /g'))
+	       EXTRARPMS=(read -a "${2//,/ }")
 	       shift 2;
 	       ;;
 	 esac


### PR DESCRIPTION
Doing away with echo | sed format to use cleaner shell search/replace