### PR TITLE
Addresses Issue 110

### DIFF
--- a/GrubSetup.sh
+++ b/GrubSetup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # shellcheck disable=SC2181
 #
 # Script to set up the chroot'ed /etc/fstab
@@ -11,6 +11,111 @@ CHROOTDEV=${1:-UNDEF}
 CHGRUBDEF="${CHROOT}/etc/default/grub"
 GRUBTMOUT="${GRUBTMOUT:-1}"
 FIPSDISABLE="${FIPSDISABLE:-UNDEF}"
+
+# Make interactive-execution more-verbose unless explicitly told not to
+if [[ $( tty -s ) -eq 0 ]] && [[ ${DEBUG} == "UNDEF" ]]
+then
+   DEBUG="true"
+fi
+
+# Error handler function
+function err_exit {
+   local ERRSTR
+   local ISNUM
+   local SCRIPTEXIT
+
+   ERRSTR="${1}"
+   ISNUM='^[0-9]+$'
+   SCRIPTEXIT="${2:-1}"
+
+   if [[ ${DEBUG} == true ]]
+   then
+      # Our output channels
+      logger -i -t "${PROGNAME}" -p kern.crit -s -- "${ERRSTR}"
+   else
+      logger -i -t "${PROGNAME}" -p kern.crit -- "${ERRSTR}"
+   fi
+
+   # Only exit if requested exit is numerical
+   if [[ ${SCRIPTEXIT} =~ ${ISNUM} ]]
+   then
+      exit "${SCRIPTEXIT}"
+   fi
+}
+
+
+# Print out a basic usage message
+function UsageMsg {
+   local SCRIPTEXIT
+   SCRIPTEXIT="${1:-1}"
+
+   (
+      echo "Usage: ${0} [GNU long option] [option] ..."
+      echo "  Options:"
+      printf '\t%-4s%s\n' '-d' 'Device GRUB2 sets up'
+      printf '\t%-4s%s\n' '-h' 'Print this message'
+      printf '\t%-4s%s\n' '-t' 'Set GRUB_TIMEOUT value in seconds (default: 1)'
+      echo "  GNU long options:"
+      printf '\t%-20s%s\n' '--grub-device' 'See "-d" short-option'
+      printf '\t%-20s%s\n' '--help' 'See "-h" short-option'
+      printf '\t%-20s%s\n' '--grub-timeout' 'See "-t" short-option'
+   )
+   exit "${SCRIPTEXIT}"
+}
+
+######################
+## Main program-flow
+######################
+OPTIONBUFR=$(getopt -o d:ht: --long grub-device:,help,grub-timeout: -n "${PROGNAME}" -- "$@")
+
+eval set -- "${OPTIONBUFR}"
+
+###################################
+# Parse contents of ${OPTIONBUFR}
+###################################
+while true
+do
+   case "$1" in
+      -d|--grub-device)
+            case "$2" in
+               "")
+                  err_exit 1 "Error: option required but not specified"
+                  shift 2;
+                  exit 1
+                  ;;
+               *)
+                  CHROOTDEV=${2}
+                  shift 2;
+                  ;;
+            esac
+            ;;
+      -h|--help)
+            UsageMsg 0
+            ;;
+      -t|--grub-timeout)
+            case "$2" in
+               "")
+                  err_exit 1 "Error: option required but not specified"
+                  shift 2;
+                  exit 1
+                  ;;
+               *)
+                  GRUBTMOUT=${2}
+                  shift 2;
+                  ;;
+            esac
+            ;;
+      --)
+         shift
+         break
+         ;;
+      *)
+         err_exit 1 "Internal error!"
+         exit 1
+         ;;
+   esac
+done
+
 
 # Check for arguments
 if [[ $# -lt 1 ]]

--- a/GrubSetup.sh
+++ b/GrubSetup.sh
@@ -9,6 +9,7 @@
 CHROOT="${AMIGENCHROOT:-/mnt/ec2-root}"
 CHROOTDEV=${1:-UNDEF}
 CHGRUBDEF="${CHROOT}/etc/default/grub"
+GRUBTMOUT="${GRUBTMOUT:-1}"
 FIPSDISABLE="${FIPSDISABLE:-UNDEF}"
 
 # Check for arguments
@@ -34,7 +35,7 @@ then
    printf "was faulty. Manufacturing a %s.\n" "${CHGRUBDEF}"
 
    (
-    printf "GRUB_TIMEOUT=1\n"
+    printf "GRUB_TIMEOUT=%s\n" "${GRUBTMOUT}"
     # shellcheck disable=2059
     printf "GRUB_DISTRIBUTOR=\"$(sed 's, release .*$,,g' /etc/system-release)\"\n"
     printf "GRUB_DEFAULT=saved\n"


### PR DESCRIPTION
Adds ability to override the `GRUB_TIMEOUT` value (per #110 ) via either shell-environment variable or commandline-argument.