### PR TITLE
Ensure default-user has appropriate SEL-mappings in sudoers

### DIFF
--- a/CleanChroot.sh
+++ b/CleanChroot.sh
@@ -60,7 +60,7 @@ system_info:\
     lock_passwd: true\
     gecos: Local Maintenance User\
     groups: [wheel, adm]\
-    sudo: ["ALL=(root) NOPASSWD:ALL"]\
+    sudo: ["ALL=(root) TYPE=sysadm_t ROLE=sysadm_r NOPASSWD:ALL"]\
     shell: /bin/bash\
     selinux_user: staff_u\
   distro: rhel\


### PR DESCRIPTION
Sets a default-mapping within sudoers for the default-user that will give them `sysadm_r` and `sysadm_t` upon elevation.

Closes #122