### PR TITLE
Move prefix-setter to more-useful location

### DIFF
--- a/MkChrootTree.sh
+++ b/MkChrootTree.sh
@@ -20,14 +20,6 @@ DEFGEOMARR=(
 DEFGEOMSTR="${DEFGEOMSTR:-$( IFS=$',' ; echo "${DEFGEOMARR[*]}" )}"
 GEOMETRYSTRING="${DEFGEOMSTR}"
 
-if [[ ${CHROOTDEV} =~ /dev/nvme ]]
-then
-   PARTPRE="p"
-else
-   PARTPRE=""
-fi
-
-
 
 
 # Print out a basic usage message
@@ -226,7 +218,13 @@ do
    esac
 done
 
-
+# Set a partition-prefix as necessary
+if [[ ${CHROOTDEV} =~ /dev/nvme ]]
+then
+   PARTPRE="p"
+else
+   PARTPRE=""
+fi
 
 BOOTDEV=${CHROOTDEV}${PARTPRE}1
 LVMDEV=${CHROOTDEV}${PARTPRE}2


### PR DESCRIPTION
Fixes issue where the spel CI tests for the GovCloud partition fail due to busy partition errors.